### PR TITLE
Fix for issue relating to writing empty objects

### DIFF
--- a/lib/qrs.js
+++ b/lib/qrs.js
@@ -98,10 +98,10 @@ var qrs = function qrs ( qrsConfig ) {
 				timeout: 2000
 			};
 
-			if ( !_.isEmpty( jsonBody ) ) {
+			if ( _.isObject( jsonBody ) ) {
 				requestOptions.json = jsonBody;
 			}
-			if ( !_.isEmpty( body ) ) {
+			if ( _.isObject( body ) ) {
 				requestOptions.body = body;
 			}
 


### PR DESCRIPTION
The use of "!_.isEmpty" makes it impossible to write empty json structures like empty arrays or empty objects. A switch to using "isObject" enables this.
